### PR TITLE
Allow custom upstreams.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ FROM multiarch/alpine:${ARCH}-edge
 LABEL maintainer="Jan Collijs"
 
 ENV DNS1 1.1.1.1
+ENV UPSTREAM1 https://${DNS1}/.well-known/dns-query
 ENV DNS2 1.0.0.1
+ENV UPSTREAM2 https://${DNS2}/.well-known/dns-query
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/main' > /etc/apk/repositories ; \
     echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories; \
@@ -30,4 +32,4 @@ HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD nslookup -po=5054 c
 
 USER cloudflared
 
-CMD ["/bin/sh", "-c", "/usr/local/bin/cloudflared proxy-dns --address 0.0.0.0 --port 5054 --upstream https://${DNS1}/.well-known/dns-query --upstream https://${DNS2}/.well-known/dns-query"]
+CMD ["/bin/sh", "-c", "/usr/local/bin/cloudflared proxy-dns --address 0.0.0.0 --port 5054 --upstream ${UPSTREAM1} --upstream ${UPSTREAM2}"]


### PR DESCRIPTION
This allows to use custom upstream servers with different uri.
`docker run --rm -e UPSTREAM1=https://doh.securedns.eu/dns-query visibilityspots/cloudflared`