### PR TITLE
Add $ADDRESS env variable to facilitate IPV6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV UPSTREAM1 https://${DNS1}/.well-known/dns-query
 ENV DNS2 1.0.0.1
 ENV UPSTREAM2 https://${DNS2}/.well-known/dns-query
 ENV PORT 5054
+ENV ADDRESS 0.0.0.0
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/main' > /etc/apk/repositories ; \
     echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories; \
@@ -36,4 +37,4 @@ HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD nslookup -po=${PORT
 
 USER cloudflared
 
-CMD ["/bin/sh", "-c", "/usr/local/bin/cloudflared proxy-dns --address 0.0.0.0 --port ${PORT} --upstream ${UPSTREAM1} --upstream ${UPSTREAM2}"]
+CMD ["/bin/sh", "-c", "/usr/local/bin/cloudflared proxy-dns --address ${ADDRESS} --port ${PORT} --upstream ${UPSTREAM1} --upstream ${UPSTREAM2}"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ a docker container which runs the [cloudflared](https://developers.cloudflare.co
 
 ### run with docker-compose
 
-``` docker-compose up -d```
+```docker-compose up -d```
 
 ### custom upstream DNS
 
@@ -21,7 +21,11 @@ a docker container which runs the [cloudflared](https://developers.cloudflare.co
 
 ### custom port
 
-``` docker run --name cloudflared --rm --net host -e PORT=5053 visibilityspots/cloudflared```
+```docker run --name cloudflared --rm --net host -e PORT=5053 visibilityspots/cloudflared```
+
+### dualstack ipv4/ipv6
+
+```docker run --name cloudflared --rm --net host -e ADDRESS :: visibilityspots/cloudflared```
 
 ## test
 
@@ -45,4 +49,5 @@ INFO: Deleting container
 ```
 
 ## License
+
 Distributed under the MIT license

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,5 @@ services:
         DNS1: 1.1.1.1
         DNS2: 1.0.0.1
         PORT: 5054
+        ADDRESS: 0.0.0.0
     restart: always


### PR DESCRIPTION
This doesn't totally solve #18 but offers a workaround for IPV6. 
- Added ENV support to all relevant locations, and left default as the current implementation
- Verified Dockerfile builds and dgoss tests pass
- This solution is documented [here](https://github.com/cloudflare/cloudflared/issues/6#issuecomment-379165518) in the cloudflare repo.
- Travis seems to have been partially failing since MR #21 but that doesn't seem related.