### PR TITLE
Fix travis docker login syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
   include:
      - stage: push
        script:
-       - echo "$DOCKER_PASSWORD" | docker login -u=visibilityspots --password-stdin
+       - echo "$DOCKER_PASSWORD" | docker login --username visibilityspots --password-stdin
        - docker pull visibilityspots/cloudflared:arm
        - docker pull visibilityspots/cloudflared:arm64
        - docker pull visibilityspots/cloudflared:amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ stages:
 script:
   - docker build -t visibilityspots/cloudflared:$TAG --build-arg ARCH="$ARCH" --build-arg GOARCH="$GOARCH" --build-arg GOARM="$GOARM" ./
   - dgoss run --name cloudflared -ti visibilityspots/cloudflared:$TAG
-  - echo "$DOCKER_PASSWORD" | docker login -u=visibilityspots --password-stdin
+  - echo "$DOCKER_PASSWORD" | docker login --username visibilityspots --password-stdin
   - docker push visibilityspots/cloudflared:$TAG
 
 jobs:


### PR DESCRIPTION
Travis has been failing for ~3 months and not pushing new images. Looks like this might be an odd syntax inconsistency with the docker cli.
- https://docs.docker.com/engine/reference/commandline/login/#provide-a-password-using-stdin
- https://stackoverflow.com/questions/51489359/docker-using-password-via-the-cli-is-insecure-use-password-stdin#:~:text=To%20run%20the%20docker%20login,history%2C%20or%20log%2Dfiles.