### PR TITLE
RFC8484 URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ FROM multiarch/alpine:${ARCH}-latest-stable
 LABEL maintainer="Jan Collijs"
 
 ENV DNS1 1.1.1.1
-ENV UPSTREAM1 https://${DNS1}/.well-known/dns-query
+ENV UPSTREAM1 https://${DNS1}/dns-query
 ENV DNS2 1.0.0.1
-ENV UPSTREAM2 https://${DNS2}/.well-known/dns-query
+ENV UPSTREAM2 https://${DNS2}/dns-query
 ENV PORT 5054
 ENV ADDRESS 0.0.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV DNS2 1.0.0.1
 ENV UPSTREAM2 https://${DNS2}/dns-query
 ENV PORT 5054
 ENV ADDRESS 0.0.0.0
-ENV METRICS 127.0.0.1
+ENV METRICS 127.0.0.1:8080
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/latest-stable/main' > /etc/apk/repositories ; \
     echo 'http://dl-cdn.alpinelinux.org/alpine/latest-stable/community' >> /etc/apk/repositories; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV DNS2 1.0.0.1
 ENV UPSTREAM2 https://${DNS2}/dns-query
 ENV PORT 5054
 ENV ADDRESS 0.0.0.0
+ENV METRICS 127.0.0.1
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/latest-stable/main' > /etc/apk/repositories ; \
     echo 'http://dl-cdn.alpinelinux.org/alpine/latest-stable/community' >> /etc/apk/repositories; \
@@ -37,4 +38,4 @@ HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD nslookup -po=${PORT
 
 USER cloudflared
 
-CMD ["/bin/sh", "-c", "/usr/local/bin/cloudflared proxy-dns --address ${ADDRESS} --port ${PORT} --upstream ${UPSTREAM1} --upstream ${UPSTREAM2}"]
+CMD ["/bin/sh", "-c", "/usr/local/bin/cloudflared proxy-dns --address ${ADDRESS} --port ${PORT} --metrics ${METRICS} --upstream ${UPSTREAM1} --upstream ${UPSTREAM2}"]


### PR DESCRIPTION
This project still uses the doh draft url e.g. https://${DNS1}/.well-known/dns-query

However .well-known should not be used anymore following RFC8484.

https://tools.ietf.org/html/rfc8484