### PR TITLE
allow setting --max-upstream-conns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV UPSTREAM2 https://1.0.0.1/dns-query
 ENV PORT 5054
 ENV ADDRESS 0.0.0.0
 ENV METRICS 127.0.0.1:8080
+ENV MAX_UPSTREAM_CONNS 0
 
 RUN adduser -S cloudflared; \
     apk add --no-cache ca-certificates bind-tools libcap; \
@@ -37,4 +38,4 @@ HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD nslookup -po=${PORT
 
 USER cloudflared
 
-CMD ["/bin/sh", "-c", "/usr/local/bin/cloudflared proxy-dns --address ${ADDRESS} --port ${PORT} --metrics ${METRICS} --upstream ${UPSTREAM1} --upstream ${UPSTREAM2}"]
+CMD ["/bin/sh", "-c", "/usr/local/bin/cloudflared proxy-dns --address ${ADDRESS} --port ${PORT} --metrics ${METRICS} --upstream ${UPSTREAM1} --upstream ${UPSTREAM2} --max-upstream-conns ${MAX_UPSTREAM_CONNS}"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ $ docker run --name cloudflared --rm --net host -e PORT=5053 visibilityspots/clo
 $ docker run --name cloudflared --rm --net host -e ADDRESS=:: visibilityspots/cloudflared:latest
 ```
 
+### limit connections to upstream dns servers
+
+```
+$ docker run --name cloudflared --rm --net host -e MAX_UPSTREAM_CONNS=5 visibilityspots/cloudflared:latest
+```
+
 ## test
 
 ```


### PR DESCRIPTION
Many people experience [the below error](
https://github.com/cloudflare/cloudflared/issues/91) on ARM:

`failed to connect to an HTTPS backend \"https://1.1.1.1/dns-query\"" error="failed to perform an HTTPS request: Post https://1.1.1.1/dns-query: net/http: request canceled (Client.Timeout exceeded while awaiting headers)`

According to https://github.com/cloudflare/cloudflared/pull/290 one can now supply the --max-upstream-conns argument to limit the amount of upstream connections being made.

This PR enables consumers of this container to specify the `MAX_UPSTREAM_CONNS` environment value to do so.
The default for MAX_UPSTREAM_CONNS is zero, meaning an unlimited amount of connections, thus the default behavior.

The argument:
https://github.com/cloudflare/cloudflared/blob/eed7d7bbc90ccaca129bc6b6c3fd18b19e6bf856/cmd/cloudflared/proxydns/cmd.go#L56
