### PR TITLE
Build against tagged upstream releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV UPSTREAM2 https://1.0.0.1/dns-query
 ENV PORT 5054
 ENV ADDRESS 0.0.0.0
 ENV METRICS 127.0.0.1:8080
+ENV MAX_UPSTREAM_CONNS 0
 
 RUN adduser -S cloudflared; \
     apk add --no-cache ca-certificates bind-tools libcap; \
@@ -37,4 +38,4 @@ HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD nslookup -po=${PORT
 
 USER cloudflared
 
-CMD ["/bin/sh", "-c", "/usr/local/bin/cloudflared proxy-dns --address ${ADDRESS} --port ${PORT} --metrics ${METRICS} --upstream ${UPSTREAM1} --upstream ${UPSTREAM2}"]
+CMD ["/bin/sh", "-c", "/usr/local/bin/cloudflared proxy-dns --address ${ADDRESS} --port ${PORT} --metrics ${METRICS} --upstream ${UPSTREAM1} --upstream ${UPSTREAM2} --max-upstream-conns ${MAX_UPSTREAM_CONNS}"]

--- a/README.md
+++ b/README.md
@@ -55,8 +55,14 @@ $ dig +short @10.0.0.2 -p 5054 visibilityspots.org
 
 ## build
 
+Build against pinned upstream release
 ```
 $ docker build -t visibilityspots/cloudflared:latest .
+```
+
+Build against a specific upstream release
+```
+$ docker build -t visibilityspots/cloudflared:latest . --build-arg UPSTREAM_RELEASE_TAG=2021.5.10
 ```
 
 ### buildx

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ $ docker run --name cloudflared --rm --net host -e PORT=5053 visibilityspots/clo
 $ docker run --name cloudflared --rm --net host -e ADDRESS=:: visibilityspots/cloudflared:latest
 ```
 
+### limit connections to upstream dns servers
+
+```
+$ docker run --name cloudflared --rm --net host -e MAX_UPSTREAM_CONNS=5 visibilityspots/cloudflared:latest
+```
+
 ## test
 
 ```


### PR DESCRIPTION
As mentioned in issue #26, the container image was built against code from upstream master.
However, upstream has been creating tagged releases for some time now.

This PR makes sure the container is build against tagged release 2021.5.10. (current latest)
It also allows to override what release to use by specifying the UPSTREAM_RELEASE_TAG argument.
E.g.:  `docker build -t visibilityspots/cloudflared:latest . --build-arg UPSTREAM_RELEASE_TAG=2021.5.10`

If the build server would poll upstream, then it would be possible to automatically generate a new container image for every upstream tagged release.

Some useful command that might help with detecting upstream tagged releases:

**Clone**
```
git clone -n https://github.com/cloudflare/cloudflared.git --depth 1 ./cloudflared
```

**Get all tags**
```
git fetch --tags
```

**Find the latest tag**
```
git describe --tags `git rev-list --tags --max-count=1`
```

**Bonus**: 
Bumped GOLANG_VERSION to 1.16.4